### PR TITLE
Working on Mac OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Runner depends on:
 
 These are very likely to be already installed on your system.
 
+**Note for Mac OS X users:**
+
+Use [Homebrew](http://brew.sh/) to install the dependencies:
+
+    brew install bash coreutils
+
 
 ## 2. Installation
 

--- a/bin/runner
+++ b/bin/runner
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
-# Mac OS X: fallback on coreutils
-if [ `which greadlink` ]; then
-  readlink="greadlink"
+# Mac OS X: fallback on homebrew coreutils
+# Detecting GNU utils http://stackoverflow.com/a/8748344/319952
+if readlink --version > /dev/null 2>&1 ; then
+  runner_readlink="readlink"
 else
-  readlink="readlink"
+  runner_readlink="/usr/local/bin/greadlink"
 fi
 
-runner_src_dir="`dirname $($readlink -f ${0})`/../src"
-runner_src_dir="`$readlink -f ${runner_src_dir}`"
+runner_src_dir="`dirname $($runner_readlink -f ${0})`/../src"
+runner_src_dir="`$runner_readlink -f ${runner_src_dir}`"
 
 source ${runner_src_dir}/runner.sh
 source ${runner_src_dir}/cli.sh

--- a/bin/runner
+++ b/bin/runner
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
+# Mac OS X: fallback on coreutils
 if [ `which greadlink` ]; then
-	alias readlink="greadlink"
+  readlink="greadlink"
+else
+  readlink="readlink"
 fi
 
-runner_src_dir="`dirname $(greadlink -f ${0})`/../src"
-runner_src_dir="`greadlink -f ${runner_src_dir}`"
+runner_src_dir="`dirname $($readlink -f ${0})`/../src"
+runner_src_dir="`$readlink -f ${runner_src_dir}`"
 
 source ${runner_src_dir}/runner.sh
 source ${runner_src_dir}/cli.sh

--- a/bin/runner
+++ b/bin/runner
@@ -1,6 +1,11 @@
-#!/bin/bash
-runner_src_dir="`dirname $(readlink -f ${0})`/../src"
-runner_src_dir="`readlink -f ${runner_src_dir}`"
+#!/usr/bin/env bash
+
+if [ `which greadlink` ]; then
+	alias readlink="greadlink"
+fi
+
+runner_src_dir="`dirname $(greadlink -f ${0})`/../src"
+runner_src_dir="`greadlink -f ${runner_src_dir}`"
 
 source ${runner_src_dir}/runner.sh
 source ${runner_src_dir}/cli.sh

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -38,7 +38,7 @@ done
 
 ## Logs a message with a timestamp
 runner_log() {
-    local date=`date +%T.%3N`
+    local date=`gdate +%T.%3N`
     echo [${runner_colors[gray]}${date}${runner_colors[reset]}] "${*}"
 }
 
@@ -56,7 +56,11 @@ runner_log_success() {
 }
 
 ## Returns unix time in ms
-alias runner_time='date +%s%3N'
+if [ `which gdate` ]; then
+    alias runner_time='gdate +%s%3N'
+else
+    alias runner_time='date +%s%3N'
+fi
 
 ## Returns a human readable duration in ms
 runner_pretty_ms() {

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -3,9 +3,9 @@
 # Mac OS X: fallback on coreutils
 # Detecting GNU utils http://stackoverflow.com/a/8748344/319952
 if date --version > /dev/null 2>&1 ; then
-  : # date is GNU
+  alias runner_date='date'
 else
-  alias date='gdate'
+  alias runner_date='gdate'
 fi
 
 ## Default task (settable with `runner_set_default_task`)
@@ -46,7 +46,7 @@ done
 
 ## Logs a message with a timestamp
 runner_log() {
-    local local_date=`date +%T.%3N`
+    local local_date=`runner_date +%T.%3N`
     echo [${runner_colors[gray]}${local_date}${runner_colors[reset]}] "${*}"
 }
 
@@ -64,7 +64,7 @@ runner_log_success() {
 }
 
 ## Returns unix time in ms
-alias runner_time="date +%s%3N"
+alias runner_time="runner_date +%s%3N"
 
 ## Returns a human readable duration in ms
 runner_pretty_ms() {

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 # Mac OS X: fallback on coreutils
-if [ `which gdate` ]; then
-  date="gdate"
+# Detecting GNU utils http://stackoverflow.com/a/8748344/319952
+if date --version > /dev/null 2>&1 ; then
+  : # date is GNU
 else
-  date="date"
+  alias date='gdate'
 fi
 
 ## Default task (settable with `runner_set_default_task`)
@@ -45,7 +46,7 @@ done
 
 ## Logs a message with a timestamp
 runner_log() {
-    local local_date=`${date} +%T.%3N`
+    local local_date=`date +%T.%3N`
     echo [${runner_colors[gray]}${local_date}${runner_colors[reset]}] "${*}"
 }
 
@@ -63,11 +64,7 @@ runner_log_success() {
 }
 
 ## Returns unix time in ms
-if [ `which gdate` ]; then
-    runner_time="${date} +%s%3N"
-else
-    runner_time="${date} +%s%3N"
-fi
+alias runner_time="date +%s%3N"
 
 ## Returns a human readable duration in ms
 runner_pretty_ms() {
@@ -176,10 +173,10 @@ runner_set_default_task() {
 runner_run_task() {
     local task_color="${runner_colors[cyan]}${1}${runner_colors[reset]}"
     runner_log "Starting '${task_color}'..."
-    local -i time_start=`${runner_time}`
+    local -i time_start=`runner_time`
     task_${1} ${runner_flags}
     local exit_code=${?}
-    local -i time_end=`${runner_time}`
+    local -i time_end=`runner_time`
     local time_diff=`runner_pretty_ms $((time_end - time_start))`
     if [[ ${exit_code} -ne 0 ]]; then
         runner_log_error "Task '${1}'" \

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Mac OS X: fallback on coreutils
+if [ `which gdate` ]; then
+  date="gdate"
+else
+  date="date"
+fi
+
 ## Default task (settable with `runner_set_default_task`)
 declare -g runner_default_task="default"
 
@@ -38,8 +45,8 @@ done
 
 ## Logs a message with a timestamp
 runner_log() {
-    local date=`gdate +%T.%3N`
-    echo [${runner_colors[gray]}${date}${runner_colors[reset]}] "${*}"
+    local local_date=`${date} +%T.%3N`
+    echo [${runner_colors[gray]}${local_date}${runner_colors[reset]}] "${*}"
 }
 
 ## Variations of log with colors
@@ -57,9 +64,9 @@ runner_log_success() {
 
 ## Returns unix time in ms
 if [ `which gdate` ]; then
-    alias runner_time='gdate +%s%3N'
+    runner_time="${date} +%s%3N"
 else
-    alias runner_time='date +%s%3N'
+    runner_time="${date} +%s%3N"
 fi
 
 ## Returns a human readable duration in ms
@@ -169,10 +176,10 @@ runner_set_default_task() {
 runner_run_task() {
     local task_color="${runner_colors[cyan]}${1}${runner_colors[reset]}"
     runner_log "Starting '${task_color}'..."
-    local -i time_start=`runner_time`
+    local -i time_start=`${runner_time}`
     task_${1} ${runner_flags}
     local exit_code=${?}
-    local -i time_end=`runner_time`
+    local -i time_end=`${runner_time}`
     local time_diff=`runner_pretty_ms $((time_end - time_start))`
     if [[ ${exit_code} -ne 0 ]]; then
         runner_log_error "Task '${1}'" \


### PR DESCRIPTION
This patch enables bash-task-runner to run on Mac OS X (tested on 10.11.1 OS X El Capitan).

Mac users should be able to use it out of the box after installing the two dependencies via homebrew or similar.

Please review. :]