### PR TITLE
Show defined tasks by default

### DIFF
--- a/src/runner.sh
+++ b/src/runner.sh
@@ -223,5 +223,5 @@ runner_bootstrap() {
         runner_run_task ${runner_default_task} || exit ${?}
         return 0
     fi
-    runner_log "Nothing to run."
+    runner_show_defined_tasks
 }


### PR DESCRIPTION
This changes the default output to show the list of defined tasks by default
instead of a dummy message if no task was called.